### PR TITLE
Allow the go2rtc add-on to use HA API

### DIFF
--- a/go2rtc/config.yaml
+++ b/go2rtc/config.yaml
@@ -11,6 +11,7 @@ slug: go2rtc
 init: false
 startup: system
 host_network: true
+homeassistant_api: true
 video: true
 audio: true
 ingress: true


### PR DESCRIPTION
This is required by https://github.com/felipecrs/hasss-expose-camera-stream-source.

- Closes https://github.com/AlexxIT/go2rtc/issues/80