### PR TITLE
Allow access to /ssl

### DIFF
--- a/go2rtc-master-hw/config.yaml
+++ b/go2rtc-master-hw/config.yaml
@@ -18,4 +18,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media" ]
+map: [ "config:rw", "media", "ssl:rw" ]

--- a/go2rtc-master-hw/config.yaml
+++ b/go2rtc-master-hw/config.yaml
@@ -18,4 +18,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media", "ssl:rw" ]
+map: [ "config:rw", "media", "ssl" ]

--- a/go2rtc-master/config.yaml
+++ b/go2rtc-master/config.yaml
@@ -17,4 +17,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media", "ssl:rw" ]
+map: [ "config:rw", "media", "ssl" ]

--- a/go2rtc-master/config.yaml
+++ b/go2rtc-master/config.yaml
@@ -17,4 +17,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media" ]
+map: [ "config:rw", "media", "ssl:rw" ]

--- a/go2rtc/config.yaml
+++ b/go2rtc/config.yaml
@@ -17,4 +17,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media", "ssl:rw" ]
+map: [ "config:rw", "media", "ssl" ]

--- a/go2rtc/config.yaml
+++ b/go2rtc/config.yaml
@@ -17,4 +17,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media" ]
+map: [ "config:rw", "media", "ssl:rw" ]


### PR DESCRIPTION
So that certificates generated by DuckDNS add-on or Let's Encrypt can be used directly with something like:

```yaml
api:
  tls_listen: ":1985"
  tls_cert: /ssl/fullchain.pem
  tls_key: /ssl/privkey.pem
```