### PR TITLE
Migrate away from Home Assistant config dir

### DIFF
--- a/go2rtc-master-hw/CHANGELOG.md
+++ b/go2rtc-master-hw/CHANGELOG.md
@@ -1,6 +1,6 @@
 This add-on now access `go2rtc.yaml` from `/addon_configs/a889bffc_go2rtc/go2rtc.yaml` instead of from `/config/go2rtc.yaml`.
 
-- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /config/addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
+- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
 - References to the Home Assistant `/config/` directory in the `go2rtc.yaml` file should be updated to `/homeassistant/`.
 
 The good news is that when this add-on is backed up, the `go2rtc.yaml` file will now be included in the backup, so you can easily restore it if needed.

--- a/go2rtc-master-hw/CHANGELOG.md
+++ b/go2rtc-master-hw/CHANGELOG.md
@@ -1,1 +1,8 @@
-See https://github.com/AlexxIT/go2rtc/releases
+This add-on now access `go2rtc.yaml` from `/addon_configs/a889bffc_go2rtc/go2rtc.yaml` instead of from `/config/go2rtc.yaml`.
+
+- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /config/addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
+- References to the Home Assistant `/config/` directory in the `go2rtc.yaml` file should be updated to `/homeassistant/`.
+
+The good news is that when this add-on is backed up, the `go2rtc.yaml` file will now be included in the backup, so you can easily restore it if needed.
+
+For go2rtc release notes, see https://github.com/AlexxIT/go2rtc/releases.

--- a/go2rtc-master-hw/config.yaml
+++ b/go2rtc-master-hw/config.yaml
@@ -18,4 +18,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media", "ssl" ]
+map: [ "addon_config:rw", "homeassistant_config", "media", "ssl" ]

--- a/go2rtc-master/CHANGELOG.md
+++ b/go2rtc-master/CHANGELOG.md
@@ -1,6 +1,6 @@
 This add-on now access `go2rtc.yaml` from `/addon_configs/a889bffc_go2rtc/go2rtc.yaml` instead of from `/config/go2rtc.yaml`.
 
-- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /config/addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
+- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
 - References to the Home Assistant `/config/` directory in the `go2rtc.yaml` file should be updated to `/homeassistant/`.
 
 The good news is that when this add-on is backed up, the `go2rtc.yaml` file will now be included in the backup, so you can easily restore it if needed.

--- a/go2rtc-master/CHANGELOG.md
+++ b/go2rtc-master/CHANGELOG.md
@@ -1,1 +1,8 @@
-See https://github.com/AlexxIT/go2rtc/releases
+This add-on now access `go2rtc.yaml` from `/addon_configs/a889bffc_go2rtc/go2rtc.yaml` instead of from `/config/go2rtc.yaml`.
+
+- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /config/addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
+- References to the Home Assistant `/config/` directory in the `go2rtc.yaml` file should be updated to `/homeassistant/`.
+
+The good news is that when this add-on is backed up, the `go2rtc.yaml` file will now be included in the backup, so you can easily restore it if needed.
+
+For go2rtc release notes, see https://github.com/AlexxIT/go2rtc/releases.

--- a/go2rtc-master/config.yaml
+++ b/go2rtc-master/config.yaml
@@ -17,4 +17,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media", "ssl" ]
+map: [ "addon_config:rw", "homeassistant_config", "media", "ssl" ]

--- a/go2rtc/CHANGELOG.md
+++ b/go2rtc/CHANGELOG.md
@@ -1,6 +1,6 @@
 This add-on now access `go2rtc.yaml` from `/addon_configs/a889bffc_go2rtc/go2rtc.yaml` instead of from `/config/go2rtc.yaml`.
 
-- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /config/addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
+- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
 - References to the Home Assistant `/config/` directory in the `go2rtc.yaml` file should be updated to `/homeassistant/`.
 
 The good news is that when this add-on is backed up, the `go2rtc.yaml` file will now be included in the backup, so you can easily restore it if needed.

--- a/go2rtc/CHANGELOG.md
+++ b/go2rtc/CHANGELOG.md
@@ -1,1 +1,8 @@
-See https://github.com/AlexxIT/go2rtc/releases
+This add-on now access `go2rtc.yaml` from `/addon_configs/a889bffc_go2rtc/go2rtc.yaml` instead of from `/config/go2rtc.yaml`.
+
+- You need to move your `go2rtc.yaml` file to the new location: `mv -v /config/go2rtc.yaml /config/addon_configs/a889bffc_go2rtc/go2rtc.yaml`.
+- References to the Home Assistant `/config/` directory in the `go2rtc.yaml` file should be updated to `/homeassistant/`.
+
+The good news is that when this add-on is backed up, the `go2rtc.yaml` file will now be included in the backup, so you can easily restore it if needed.
+
+For go2rtc release notes, see https://github.com/AlexxIT/go2rtc/releases.

--- a/go2rtc/config.yaml
+++ b/go2rtc/config.yaml
@@ -6,9 +6,9 @@ image: alexxit/go2rtc
 arch: [ amd64, aarch64, i386, armv7 ]
 
 # https://developers.home-assistant.io/docs/add-ons/configuration
-version: 1.9.10
+version: 1.9.11
 breaking_versions:
-  - 1.9.10
+  - 1.9.11
 slug: go2rtc
 init: false
 startup: system

--- a/go2rtc/config.yaml
+++ b/go2rtc/config.yaml
@@ -6,7 +6,9 @@ image: alexxit/go2rtc
 arch: [ amd64, aarch64, i386, armv7 ]
 
 # https://developers.home-assistant.io/docs/add-ons/configuration
-version: 1.9.9
+version: 1.9.10
+breaking_versions:
+  - 1.9.10
 slug: go2rtc
 init: false
 startup: system
@@ -17,4 +19,4 @@ audio: true
 ingress: true
 ingress_port: 1984
 panel_icon: mdi:camera-wireless
-map: [ "config:rw", "media", "ssl" ]
+map: [ "addon_config:rw", "homeassistant_config", "media", "ssl" ]


### PR DESCRIPTION
@alexxit, this should only be merged after the next version of go2rtc is released.

There will be a PR in the go2rtc repository updating the default hass.config to `/homeassistant/` to ease the transition.

Closes https://github.com/AlexxIT/go2rtc/issues/1649
